### PR TITLE
Feature/2/view for timers

### DIFF
--- a/timing/.gitignore
+++ b/timing/.gitignore
@@ -19,7 +19,7 @@ migrate_working_dir/
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
+# .vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/
@@ -42,3 +42,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+

--- a/timing/.vscode/launch.json
+++ b/timing/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "timing",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "timing (profile mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "timing (release mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        }
+    ]
+}

--- a/timing/analysis_options.yaml
+++ b/timing/analysis_options.yaml
@@ -8,11 +8,11 @@ linter:
   # https://dart-lang.github.io/linter/lints/index.html.
   #
   rules:
-    avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
-    prefer_const_constructors: false
-    prefer_final_fields: false
-    use_key_in_widget_constructors: false
-    prefer_const_literals_to_create_immutables: false
-    prefer_const_constructors_in_immutables: false
+    # prefer_const_constructors: false
+    # prefer_final_fields: false
+    # use_key_in_widget_constructors: false
+    # prefer_const_literals_to_create_immutables: false
+    # prefer_const_constructors_in_immutables: false

--- a/timing/lib/main.dart
+++ b/timing/lib/main.dart
@@ -1,3 +1,7 @@
+
+
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -10,43 +14,45 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a blue toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    return ChangeNotifierProvider(
+      create: (context) => MyAppState(),
+      child: MaterialApp(
+        title: 'Timing',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+          useMaterial3: true,
+        ),
+        home: const MyHomePage(title: 'Timers'),
+      )
     );
   }
 }
 
+class MyAppState extends ChangeNotifier {
+  // List<TimerClock> timers = List.empty(growable: true);
+  List<TimerClock> timers = [];
+  
+  void timerStartStop(index) {
+
+    // if(timers[index].status == true) {
+    //   timers[index].stopTimer();
+    // } else {
+    //   timers[index].startTimer();
+    // }
+    print('Started/Stopped timer');
+    // notifyListeners();
+  }
+
+  void addTimer() {
+    timers.add(TimerClock());
+    print('Added timer');
+    notifyListeners();
+  }
+  //TO-DO: Add timer and Delete Timer functions
+}
+
 class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
 
   final String title;
 
@@ -54,72 +60,173 @@ class MyHomePage extends StatefulWidget {
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
 
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
+class Pair<T> {
+  late final T a;
+  late final T b;
+
+  Pair(this.a, this.b);
+}
+
+
+class TimerClock {
+  late DateTime start;
+  late DateTime end;
+  late Duration running;
+  bool status = false;
+  late String name;
+  late List<Pair<DateTime>> past;
+
+  TimerClock() {
+    running = Duration.zero;
+    past = [];
   }
+
+  void set(start, end, status, name) {
+    this.start = start;
+    this.end = end;
+    this.status = status;
+    running = Duration.zero;
+    past = [];
+    this.name = name;
+  }
+
+  void setName(name) {
+    this.name = name;
+  }
+
+  void startTimer() {
+    status = true;
+    start = DateTime.now();
+    print('Started timer');
+  }
+
+  void stopTimer() {
+    status = false;
+    end = DateTime.now();
+    print('Running before: $running');
+
+    running = running + end.difference(start);
+    past.add(Pair<DateTime>(start, end));
+    print('Stopped timer $running');
+  }
+  
+  void toggleTimer() {
+    if(status == true) {
+      stopTimer();
+    } else {
+      startTimer();
+    }
+  }
+}
+
+
+class _MyHomePageState extends State<MyHomePage> {
+
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
+
+    var appState = context.watch<MyAppState>();
+
+    var timersCount = appState.timers.length;
+
+    if(appState.timers.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(
+          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+          title: Text(widget.title),
+          actions: <Widget>[
+            IconButton(
+              onPressed: () {
+                appState.addTimer();
+                print('Timer added');
+              },
+              icon: const Icon(Icons.add_alarm_outlined))
+          ],
+        ),
+        body: const Center(
+          child: Text('No timers yet'),
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
         title: Text(widget.title),
+        actions: <Widget>[
+          IconButton(
+            onPressed: () {
+              appState.addTimer();
+            },
+            icon: const Icon(Icons.add_alarm_outlined))
+        ],
       ),
       body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
         child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
+          children: <Widget> [
             const Text(
-              'You have pressed the button this many times:',
+              'Number of timers:',
             ),
             Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+              '$timersCount'
+            ),  
+            Expanded(
+              child: ListView(
+                  children: <Widget>[
+                    for(final t in appState.timers) 
+                      TimerView(t: t),
+                  ],
+                ),
             ),
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+    );
+  }
+}
+
+class TimerView extends StatelessWidget {
+  TimerView({
+    super.key,
+    required this.t,
+  });
+
+  final TimerClock t;
+
+  final numFormat = NumberFormat('00', 'en_US');
+
+  
+
+  @override
+  Widget build(BuildContext context) {
+  
+  final theme = Theme.of(context);
+  final timeStyle = theme.textTheme.displayMedium;//!.copyWith(color: theme.colorScheme.onSecondary);
+  // final cardStyle = theme.colorScheme.primary;
+  
+    return Center(
+      child: Card(
+        child: InkWell(
+          onLongPress: () => {
+            print('Long pressed this one')
+          },
+          onTap: () => { 
+            t.toggleTimer()
+          },
+          child: SizedBox(
+            height: 120,
+            width: 180,
+            child: Center(
+              child: Text(
+                '${numFormat.format(t.running.inMinutes)}:${numFormat.format(t.running.inSeconds%60)}',
+                style: timeStyle
+                ),
+            ),
+            ),
+        ),
+      ),
     );
   }
 }

--- a/timing/pubspec.lock
+++ b/timing/pubspec.lock
@@ -75,6 +75,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.1"
   js:
     dependency: transitive
     description:
@@ -115,6 +123,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -123,6 +139,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -186,3 +210,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=3.0.5 <4.0.0"
+  flutter: ">=1.16.0"

--- a/timing/pubspec.yaml
+++ b/timing/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
 
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  provider: ^6.0.0
+  intl: ^0.18.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Closes #2 

This PR also adds partial functionality of Timers from #4 and timer details from #6. The timers start, stop, and display the running time in seconds. 

The deletion of timers is done by long-pressing on the timer, which opens the timer edit page which contains the delete button.

This will be replaced with Timer Details, and an option to edit, where the delete button will be placed.
That's just adding a new page between the timers page and the current edit page. That new page added in between will have timer details like the start-stop times in the past, separated by day. 


